### PR TITLE
Add recovery services vault and backup policy

### DIFF
--- a/modules/storage/backup_policy/main.tf
+++ b/modules/storage/backup_policy/main.tf
@@ -1,0 +1,20 @@
+module "backup_policy" {
+  source     = "../../../."
+  name       = var.name
+  prefixes   = var.prefixes
+  suffixes   = var.suffixes
+  separator  = "-"
+  max_length = 130
+  nb_instances = var.nb_instances
+}
+
+data "null_data_source" "names" {
+  count = var.nb_instances
+  inputs = {
+    result = var.nb_instances > 1 ? regex("^[a-zA-Z0-9]{1}[a-zA-Z0-9-][^-]*$", module.backup_policy.results[count.index]) : regex("^[a-zA-Z0-9]{1}[a-zA-Z0-9-][^-]*$", module.backup_policy.result)
+  }
+}
+
+locals {
+  results = data.null_data_source.names.*.outputs.result
+}

--- a/modules/storage/backup_policy/outputs.tf
+++ b/modules/storage/backup_policy/outputs.tf
@@ -1,0 +1,9 @@
+output "result" {
+  description = "The generated backup policy name."
+  value       = local.results[0]
+}
+
+output "results" {
+  description = "The generated backup policy names."
+  value       = local.results
+}

--- a/modules/storage/backup_policy/variables.tf
+++ b/modules/storage/backup_policy/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "backup policy name."
+  type        = string
+}
+
+variable "prefixes" {
+  description = "List of prefixes to append in front of the resource name."
+  type        = list(string)
+}
+
+variable "suffixes" {
+  description = "List of suffixes to append at the end of the resource name."
+  type        = list(string)
+  default     = []
+}
+
+variable "nb_instances" {
+  default = 1
+}

--- a/modules/storage/backup_policy/versions.tf
+++ b/modules/storage/backup_policy/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/storage/recovery_services_vault/main.tf
+++ b/modules/storage/recovery_services_vault/main.tf
@@ -1,0 +1,20 @@
+module "recovery_services_vault" {
+  source     = "../../../."
+  name       = var.name
+  prefixes   = var.prefixes
+  suffixes   = var.suffixes
+  separator  = "-"
+  max_length = 50
+  nb_instances = var.nb_instances
+}
+
+data "null_data_source" "names" {
+  count = var.nb_instances
+  inputs = {
+    result = var.nb_instances > 1 ? regex("^[a-zA-Z0-9]{1}[a-zA-Z0-9-]*$", module.recovery_services_vault.results[count.index]) : regex("^[a-zA-Z0-9]{1}[a-zA-Z0-9-]*$", module.recovery_services_vault.result)
+  }
+}
+
+locals {
+  results = data.null_data_source.names.*.outputs.result
+}

--- a/modules/storage/recovery_services_vault/outputs.tf
+++ b/modules/storage/recovery_services_vault/outputs.tf
@@ -1,0 +1,9 @@
+output "result" {
+  description = "The generated recovery services vault name."
+  value       = local.results[0]
+}
+
+output "results" {
+  description = "The generated recovery services vault names."
+  value       = local.results
+}

--- a/modules/storage/recovery_services_vault/variables.tf
+++ b/modules/storage/recovery_services_vault/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "recovery services vault name."
+  type        = string
+}
+
+variable "prefixes" {
+  description = "List of prefixes to append in front of the resource name."
+  type        = list(string)
+}
+
+variable "suffixes" {
+  description = "List of suffixes to append at the end of the resource name."
+  type        = list(string)
+  default     = []
+}
+
+variable "nb_instances" {
+  default = 1
+}

--- a/modules/storage/recovery_services_vault/versions.tf
+++ b/modules/storage/recovery_services_vault/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/templating/data.json
+++ b/templating/data.json
@@ -278,6 +278,24 @@
             "max_length": 50,
             "separator": "-",
             "regex": "^[a-zA-Z0-9]{1}[a-zA-Z0-9-_.]*$"
+        },
+        {
+            "source": "../../../.",
+            "name": "recovery_services_vault",
+            "long_name": "recovery services vault",
+            "category": "storage",
+            "max_length": 50,
+            "separator": "-",
+            "regex": "^[a-zA-Z0-9]{1}[a-zA-Z0-9-]*$"
+        },
+        {
+            "source": "../../../.",
+            "name": "backup_policy",
+            "long_name": "backup policy",
+            "category": "storage",
+            "max_length": 130,
+            "separator": "-",
+            "regex": "^[a-zA-Z0-9]{1}[a-zA-Z0-9-][^-]*$"
         }
     ]
 }


### PR DESCRIPTION
This PR adds `recovery_services_vault` and `backup_policy` modules.

See also:
* [Azure Resource Manager: azurerm_backup_container_storage_account - Terraform by HashiCorp](https://www.terraform.io/docs/providers/azurerm/r/backup_container_storage_account.html)
* [https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftrecoveryservices](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftrecoveryservices)

I was unsure about in what category I should place this module and should I create `recovery_services` one. But when I had discovered that `key_vault` is in `general` I decided that new ones fit well to `storage`.